### PR TITLE
Connecting to 139 port using Netbios hostname.

### DIFF
--- a/src/jcifs/netbios/NbtAddress.java
+++ b/src/jcifs/netbios/NbtAddress.java
@@ -164,6 +164,7 @@ public final class NbtAddress {
     }
 
     static NbtAddress localhost;
+    public static boolean localhostSet = true;
 
     static {
         InetAddress localInetAddress;
@@ -203,6 +204,7 @@ public final class NbtAddress {
         localHostname = Config.getProperty( "jcifs.netbios.hostname", null );
         if( localHostname == null || localHostname.length() == 0 ) {
             byte[] addr = localInetAddress.getAddress();
+            localhostSet = false;
             localHostname = "JCIFS" +
                     ( addr[2] & 0xFF ) + "_" +
                     ( addr[3] & 0xFF ) + "_" +

--- a/src/jcifs/smb/SmbTransport.java
+++ b/src/jcifs/smb/SmbTransport.java
@@ -322,9 +322,17 @@ public class SmbTransport extends Transport implements SmbConstants {
          */
 
         SmbComNegotiateResponse resp = new SmbComNegotiateResponse( server );
+
+        if (NbtAddress.localhostSet) {
+            port = 139;
+        }
+
         try {
             negotiate( port, resp );
         } catch( ConnectException ce ) {
+            if (NbtAddress.localhostSet)
+                throw ce;
+
             port = (port == 0 || port == DEFAULT_PORT) ? 139 : DEFAULT_PORT;
             negotiate( port, resp );
         } catch( NoRouteToHostException nr ) {


### PR DESCRIPTION
 There was a 'Logon failure: user not allowed to log on to this computer.' exception during AD authentication attempt.

 AD contains field 'User workstation' which allowes user to login using only specified in this field hosts.
 If hostname specified in 'User workstation' does not match name stored in request then the exception 'Logon failure ' is thrown.
 Name can be contained in request if and only if its run via NETBIOS (137, 138, 139 ports).
 Attempt to login directly via 445 will couse to 'Login failure ...' exception because AD will receive hosts IP address instead of its name.

 This patch changes the SMB port to 139 if the jcifs.netbios.hostname is specified.
